### PR TITLE
Added help command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ include(cmake/configured-files.cmake)
 add_executable(citescoop-cli_exe
   src/commands/base_command.cc
   src/commands/extract_command.cc
+  src/commands/help_command.cc
   src/cli.cc
   src/main.cc
 )

--- a/src/cli.cc
+++ b/src/cli.cc
@@ -38,7 +38,7 @@ Cli::Cli() : global_options_("Global options") {
   positional_options_.add("command", 1).add("subargs", -1);
 }
 
-void Cli::Register(std::unique_ptr<BaseCommand> command) {
+void Cli::Register(std::shared_ptr<BaseCommand> command) {
   spdlog::trace("Registering command {}", command->name());
   this->commands_.insert({command->name(), std::move(command)});
 }
@@ -129,6 +129,9 @@ void Cli::PrintGlobalHelp() {
                              command->description())
               << '\n';
   }
+
+  std::cout << '\n' << "To get command specific help, use:" << '\n';
+  std::cout << "citescoop-cli help <command>" << '\n';
 }
 
 bool Cli::HandleImmediateExecutionFlags(const options::variables_map& args) {

--- a/src/cli.h
+++ b/src/cli.h
@@ -25,7 +25,7 @@ class Cli {
   /// @brief Registers a command within the CLI.
   ///
   /// @param command Command to register.
-  void Register(std::unique_ptr<BaseCommand> command);
+  void Register(std::shared_ptr<BaseCommand> command);
 
   /// @brief Run the specified command if it exists. If the command
   /// specified does not exist, an exception will be thrown.
@@ -69,7 +69,7 @@ class Cli {
       const boost::program_options::variables_map& args);
 
   // Mapping of command name to command
-  std::map<std::string, std::unique_ptr<BaseCommand>> commands_;
+  std::map<std::string, std::shared_ptr<BaseCommand>> commands_;
 
   boost::program_options::options_description global_options_;
   boost::program_options::positional_options_description positional_options_;

--- a/src/commands/base_command.cc
+++ b/src/commands/base_command.cc
@@ -29,8 +29,10 @@ void BaseCommand::PrintHelp() {
 
 std::pair<options::variables_map, options::parsed_options>
 BaseCommand::ParseArgs(std::vector<std::string> args) {
-  const options::parsed_options parsed =
-      options::command_line_parser(args).options(cli_options_).run();
+  const options::parsed_options parsed = options::command_line_parser(args)
+                                             .options(cli_options_)
+                                             .positional(positional_options_)
+                                             .run();
 
   options::variables_map cli_variables;
   options::store(parsed, cli_variables);

--- a/src/commands/base_command.h
+++ b/src/commands/base_command.h
@@ -11,6 +11,7 @@
 
 #include "boost/program_options/options_description.hpp"
 #include "boost/program_options/parsers.hpp"
+#include "boost/program_options/positional_options.hpp"
 #include "boost/program_options/variables_map.hpp"
 #include "spdlog/common.h"
 
@@ -45,6 +46,7 @@ class BaseCommand {
   std::string name_;
   std::string description_;
   boost::program_options::options_description cli_options_;
+  boost::program_options::positional_options_description positional_options_;
 };
 
 }  // namespace wikiopencite::citescoop::cli

--- a/src/commands/help_command.cc
+++ b/src/commands/help_command.cc
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2025 The University of St Andrews
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "help_command.h"
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "boost/program_options/options_description.hpp"
+#include "boost/program_options/parsers.hpp"
+#include "boost/program_options/positional_options.hpp"
+#include "boost/program_options/value_semantic.hpp"
+#include "boost/program_options/variables_map.hpp"
+
+namespace options = boost::program_options;
+
+namespace wikiopencite::citescoop::cli {
+HelpCommand::HelpCommand(
+    std::shared_ptr<std::vector<std::shared_ptr<BaseCommand>>> commands)
+    : BaseCommand("help", "Show help information for a given command") {
+
+  commands_ = commands;
+  cli_options_.add_options()("command",
+                             options::value<std::string>()->required(),
+                             "Command to show help text for");
+  positional_options_.add("command", 1);
+}
+
+int HelpCommand::Run(std::vector<std::string> args,
+                     struct GlobalOptions globals) {
+  auto parsed_args = ParseArgs(args);
+
+  auto command_name = parsed_args.first["command"].as<std::string>();
+
+  for (const auto& command : *commands_) {
+    if (command->name() == command_name) {
+      command->PrintHelp();
+      return EXIT_SUCCESS;
+    }
+  }
+
+  std::cout << "No command with name: " << command_name << '\n';
+
+  return EXIT_FAILURE;
+}
+
+}  // namespace wikiopencite::citescoop::cli

--- a/src/commands/help_command.h
+++ b/src/commands/help_command.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2025 The University of St Andrews
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SRC_COMMANDS_HELP_COMMAND_H_
+#define SRC_COMMANDS_HELP_COMMAND_H_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "base_command.h"
+
+namespace wikiopencite::citescoop::cli {
+
+class HelpCommand : public BaseCommand {
+ public:
+  HelpCommand(
+      std::shared_ptr<std::vector<std::shared_ptr<BaseCommand>>> commands);
+  int Run(std::vector<std::string> args, GlobalOptions globals) override;
+
+ private:
+  std::shared_ptr<std::vector<std::shared_ptr<BaseCommand>>> commands_;
+};
+
+}  // namespace wikiopencite::citescoop::cli
+
+#endif  // SRC_COMMANDS_HELP_COMMAND_H_

--- a/src/main.cc
+++ b/src/main.cc
@@ -15,6 +15,7 @@
 #include "cli.h"
 #include "commands/base_command.h"
 #include "commands/extract_command.h"
+#include "commands/help_command.h"
 
 namespace cli = wikiopencite::citescoop::cli;
 
@@ -42,7 +43,17 @@ auto main(int argc, char** argv) -> int {
   SetDebug();
 
   cli::Cli cli = cli::Cli();
-  cli.Register(std::unique_ptr<cli::BaseCommand>(new cli::ExtractCommand()));
+
+  auto commands =
+      std::make_shared<std::vector<std::shared_ptr<cli::BaseCommand>>>();
+
+  auto command = std::shared_ptr<cli::BaseCommand>(new cli::ExtractCommand());
+  commands->push_back(command);
+  cli.Register(command);
+
+  command = std::shared_ptr<cli::BaseCommand>(new cli::HelpCommand(commands));
+  commands->push_back(command);
+  cli.Register(command);
 
   return cli.Run(argc, argv);
 }


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The University of St Andrews
SPDX-License-Identifier: CC0-1.0
-->

<!--
This PR template is designed to help you write PRs that are easy for us
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary

A very basic help command to print out help messages for subcommands has been added. The command can be registered at any point and takes a pointer to a vector of pointers to all other commands.

An update to the global help has also been made to include a note directing the user to use the help command for command specific help.

<!-- A brief, mostly non technical summary of what this change does -->

Closes #

- [ ] Breaking Change?

# Technical Description

<!--
How does this change work? Why was this approach chosen? Were any
alternative approaches considered?
-->

## Usage

<!--
How should this change be used? Are there any changes to existing
usage, e.g. API?
-->

# Self Review

- [ ] I have commented my code where needed, including JSDoc / TSDoc / Docstring
- [ ] I have added / updated tests
- [ ] I have reviewed my code to ensure there are no artifacts left over from development
- [ ] I have tested my code to ensure it functions as intended
