### PR TITLE
Improve error handling

### DIFF
--- a/src/cli.cc
+++ b/src/cli.cc
@@ -43,8 +43,7 @@ void Cli::Register(std::shared_ptr<BaseCommand> command) {
   this->commands_.insert({command->name(), std::move(command)});
 }
 
-int Cli::Run(int argc,
-             char* argv[]) {  // NOLINT(modernize-avoid-c-arrays)
+int Cli::Run(int argc, char* argv[]) {  // NOLINT(modernize-avoid-c-arrays)
   spdlog::trace("Got request to run command");
 
   auto parsed_global_args = ParseGlobalArgs(argc, argv);
@@ -74,7 +73,13 @@ int Cli::Run(int argc,
   command_args.erase(command_args.begin());
 
   spdlog::debug("Running command {}", cmd);
-  auto r_code = commands_.at(cmd)->Run(command_args, global_args);
+  int r_code;
+  try {
+    r_code = commands_.at(cmd)->Run(command_args, global_args);
+  } catch (const std::exception& e) {
+    std::cout << e.what() << '\n';
+    return EXIT_FAILURE;
+  }
   spdlog::debug("Command exited with code {}", r_code);
   return r_code;
 }
@@ -87,6 +92,7 @@ void Cli::PrintVersion() {
 }
 
 GlobalOptions Cli::GlobalArgsToStruct(
+    // NOLINTNEXTLINE(whitespace/indent_namespace)
     const boost::program_options::variables_map& args) {
 
   GlobalOptions options;


### PR DESCRIPTION
Actually catch the errors we throw in CLI as we run commands to avoid printing internal details

<!--
SPDX-FileCopyrightText: 2025 The University of St Andrews
SPDX-License-Identifier: CC0-1.0
-->

<!--
This PR template is designed to help you write PRs that are easy for us
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary

Quick and dirty fix for error handling

This very much violates the idea of #13 but it is better than just letting the system catch the exceptions and return a nasty message.

<!-- A brief, mostly non technical summary of what this change does -->

Closes #

- [ ] Breaking Change?

# Technical Description

<!--
How does this change work? Why was this approach chosen? Were any
alternative approaches considered?
-->

## Original Bug Description

<!--
A brief description of the original bug that was fixed by this change.
-->

# Self Review

- [ ] I have commented my code where needed, including JSDoc / TSDoc / Docstring
- [ ] I have added / updated tests
- [ ] I have reviewed my code to ensure there are no artifacts left over from development
- [ ] I have tested my code to ensure it functions as intended
