### PR TITLE
Add cat and meta commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(citescoop-cli_exe
   src/commands/cat_command.cc
   src/commands/extract_command.cc
   src/commands/help_command.cc
+  src/commands/meta_command.cc
   src/cli.cc
   src/langmap.cc
   src/main.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_executable(citescoop-cli_exe
   src/commands/base_command.cc
+  src/commands/cat_command.cc
   src/commands/extract_command.cc
   src/commands/help_command.cc
   src/cli.cc

--- a/src/commands/base_command.cc
+++ b/src/commands/base_command.cc
@@ -3,15 +3,20 @@
 
 #include "base_command.h"
 
+#include <arpa/inet.h>
 #include <iostream>
 #include <string>
 #include <utility>
 #include <vector>
 
+#include "spdlog/spdlog.h"
+
 #include "boost/program_options/parsers.hpp"
 #include "boost/program_options/variables_map.hpp"
 #include "citescoop/version.h"
 #include "fmt/format.h"
+
+#include "exceptions.h"
 
 namespace options = boost::program_options;
 

--- a/src/commands/base_command.cc
+++ b/src/commands/base_command.cc
@@ -3,20 +3,15 @@
 
 #include "base_command.h"
 
-#include <arpa/inet.h>
 #include <iostream>
 #include <string>
 #include <utility>
 #include <vector>
 
-#include "spdlog/spdlog.h"
-
 #include "boost/program_options/parsers.hpp"
 #include "boost/program_options/variables_map.hpp"
 #include "citescoop/version.h"
 #include "fmt/format.h"
-
-#include "exceptions.h"
 
 namespace options = boost::program_options;
 

--- a/src/commands/base_command.h
+++ b/src/commands/base_command.h
@@ -4,7 +4,9 @@
 #ifndef SRC_COMMANDS_BASE_COMMAND_H_
 #define SRC_COMMANDS_BASE_COMMAND_H_
 
+#include <arpa/inet.h>
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -13,7 +15,10 @@
 #include "boost/program_options/parsers.hpp"
 #include "boost/program_options/positional_options.hpp"
 #include "boost/program_options/variables_map.hpp"
-#include "spdlog/common.h"
+#include "google/protobuf/message.h"
+#include "spdlog/spdlog.h"
+
+#include "exceptions.h"
 
 namespace wikiopencite::citescoop::cli {
 struct GlobalOptions {
@@ -42,7 +47,38 @@ class BaseCommand {
  protected:
   std::pair<boost::program_options::variables_map,
             boost::program_options::parsed_options>
-  ParseArgs(const std::vector<std::string>& args);
+  ParseArgs(std::vector<std::string> args);
+
+  template <typename T>
+  T EnsureArgument(std::string arg,
+                   // NOLINTNEXTLINE(whitespace/indent_namespace)
+                   boost::program_options::variables_map args) {
+    if (!args.count(arg)) {
+      throw MissingArgumentException("Missing required argument " + arg);
+    }
+
+    return args[arg].as<T>();
+  }
+
+  template <class T, typename std::enable_if<std::is_base_of<
+                         google::protobuf::Message, T>::value>::type* = nullptr>
+  std::pair<uint32_t, std::unique_ptr<T>> ReadMessage(
+      const google::protobuf::io::CodedInputStream& input) {
+    // Read the message size
+    uint32_t size;
+    input.ReadRaw(&size, sizeof(size));
+    size = ntohl(size);
+
+    spdlog::trace("Size of message to read is {}", size);
+
+    auto message = std::make_unique<T>();
+    auto limit = input.PushLimit(size);
+    message->ParseFromCodedStream(&input);
+    input.PopLimit(limit);
+
+    return std::make_pair(size, std::move(message));
+  }
+
   std::string name_;
   std::string description_;
   boost::program_options::options_description cli_options_;

--- a/src/commands/base_command.h
+++ b/src/commands/base_command.h
@@ -4,9 +4,9 @@
 #ifndef SRC_COMMANDS_BASE_COMMAND_H_
 #define SRC_COMMANDS_BASE_COMMAND_H_
 
-#include <arpa/inet.h>
+#include <arpa/inet.h>  // NOLINT(misc-include-cleaner)
+
 #include <cstdint>
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -15,8 +15,7 @@
 #include "boost/program_options/parsers.hpp"
 #include "boost/program_options/positional_options.hpp"
 #include "boost/program_options/variables_map.hpp"
-#include "google/protobuf/message.h"
-#include "spdlog/spdlog.h"
+#include "spdlog/common.h"
 
 #include "exceptions.h"
 
@@ -47,39 +46,17 @@ class BaseCommand {
  protected:
   std::pair<boost::program_options::variables_map,
             boost::program_options::parsed_options>
-  ParseArgs(std::vector<std::string> args);
+  ParseArgs(const std::vector<std::string>& args);
 
   template <typename T>
-  T EnsureArgument(std::string arg,
+  T EnsureArgument(const std::string& arg,
                    // NOLINTNEXTLINE(whitespace/indent_namespace)
-                   boost::program_options::variables_map args) {
-    if (!args.count(arg)) {
+                   const boost::program_options::variables_map& args) {
+    if (!args.contains(arg)) {
       throw MissingArgumentException("Missing required argument " + arg);
     }
 
     return args[arg].as<T>();
-  }
-
-  template <class T, typename std::enable_if<std::is_base_of<
-                         google::protobuf::Message, T>::value>::type* = nullptr>
-  std::pair<uint32_t, std::unique_ptr<T>> ReadMessage(
-      std::shared_ptr<google::protobuf::io::CodedInputStream> input) {
-    // Read the message size
-    uint32_t size;
-
-    input->ReadRaw(&size, sizeof(size));
-    size = ntohl(size);
-
-    auto message = std::make_unique<T>();
-
-    auto limit = input->PushLimit(size);
-    message->ParseFromCodedStream(input.get());
-    input->PopLimit(limit);
-
-    spdlog::trace("Read message {} from disk. Size: disk: {} memory: {}",
-                  message->GetTypeName(), size, message->SpaceUsedLong());
-
-    return std::make_pair(size, std::move(message));
   }
 
   std::string name_;

--- a/src/commands/cat_command.cc
+++ b/src/commands/cat_command.cc
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2025 The University of St Andrews
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "cat_command.h"
+
+#include <arpa/inet.h>
+// NOLINTNEXTLINE(build/c++17)
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <ostream>
+#include <regex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "boost/program_options/options_description.hpp"
+#include "boost/program_options/parsers.hpp"
+#include "boost/program_options/positional_options.hpp"
+#include "boost/program_options/value_semantic.hpp"
+#include "boost/program_options/variables_map.hpp"
+#include "citescoop/proto/file_header.pb.h"
+#include "citescoop/proto/page.pb.h"
+#include "citescoop/proto/revision_map.pb.h"
+#include "google/protobuf/io/coded_stream.h"
+#include "google/protobuf/io/zero_copy_stream.h"
+#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "spdlog/spdlog.h"
+
+#include "exceptions.h"
+
+namespace options = boost::program_options;
+namespace fs = std::filesystem;
+namespace cs = wikiopencite::citescoop;
+namespace proto = wikiopencite::proto;
+
+namespace wikiopencite::citescoop::cli {
+CatCommand::CatCommand()
+    // NOLINTNEXTLINE(whitespace/indent_namespace)
+    : BaseCommand("cat", "Display a pbf file") {
+  // clang-format off
+  cli_options_.add_options()
+    ("file", options::value<std::string>()->required(), "Input file.");
+  positional_options_.add("file", 1);
+
+  // clang-format on
+}
+
+int CatCommand::Run(std::vector<std::string> args,
+                    // NOLINTNEXTLINE(whitespace/indent_namespace)
+                    struct GlobalOptions) {
+  auto parsed_args = ParseArgs(args);
+  auto file = fs::path(EnsureArgument<std::string>("file", parsed_args.first));
+
+  std::ifstream input(file, std::ios::in | std::ios::binary);
+  auto raw_input = google::protobuf::io::IstreamInputStream(&input);
+  auto coded_input = google::protobuf::io::CodedInputStream(&raw_input);
+
+  auto header = ReadMessage<proto::FileHeader>(coded_input);
+  std::shared_ptr<proto::FileHeader> header_message = std::move(header.second);
+  PrintMessage(header_message, header.first);
+
+  auto revisions = ReadMessage<proto::RevisionMap>(coded_input);
+  std::shared_ptr<proto::RevisionMap> revisions_message =
+      std::move(revisions.second);
+  PrintMessage(revisions_message, revisions.first);
+
+  for (int64_t i = 0; i < header_message->page_count(); i++) {
+    auto page = ReadMessage<proto::Page>(coded_input);
+    std::shared_ptr<proto::Page> page_message = std::move(page.second);
+    PrintMessage(page_message, page.first);
+  }
+
+  return EXIT_SUCCESS;
+}
+
+void CatCommand::PrintMessage(
+    // NOLINTNEXTLINE(whitespace/indent_namespace)
+    std::shared_ptr<google::protobuf::Message> message, uint32_t size) {
+  std::cout << message->GetTypeName() << " : " << size << " bytes" << '\n';
+  std::cout << message->DebugString() << '\n';
+}
+
+}  // namespace wikiopencite::citescoop::cli

--- a/src/commands/cat_command.cc
+++ b/src/commands/cat_command.cc
@@ -55,7 +55,8 @@ int CatCommand::Run(std::vector<std::string> args,
 
   std::ifstream input(file, std::ios::in | std::ios::binary);
   auto raw_input = google::protobuf::io::IstreamInputStream(&input);
-  auto coded_input = google::protobuf::io::CodedInputStream(&raw_input);
+  auto coded_input =
+      std::make_shared<google::protobuf::io::CodedInputStream>(&raw_input);
 
   auto header = ReadMessage<proto::FileHeader>(coded_input);
   std::shared_ptr<proto::FileHeader> header_message = std::move(header.second);

--- a/src/commands/cat_command.cc
+++ b/src/commands/cat_command.cc
@@ -3,14 +3,13 @@
 
 #include "cat_command.h"
 
-#include <arpa/inet.h>
-// NOLINTNEXTLINE(build/c++17)
-#include <filesystem>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>  // NOLINT(build/c++17)
 #include <fstream>
 #include <iostream>
 #include <memory>
 #include <ostream>
-#include <regex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -19,23 +18,20 @@
 #include "boost/program_options/parsers.hpp"
 #include "boost/program_options/positional_options.hpp"
 #include "boost/program_options/value_semantic.hpp"
-#include "boost/program_options/variables_map.hpp"
+#include "citescoop/io.h"
 #include "citescoop/proto/file_header.pb.h"
 #include "citescoop/proto/page.pb.h"
-#include "citescoop/proto/revision_map.pb.h"
-#include "google/protobuf/io/coded_stream.h"
-#include "google/protobuf/io/zero_copy_stream.h"
-#include "google/protobuf/io/zero_copy_stream_impl.h"
-#include "spdlog/spdlog.h"
+#include "citescoop/proto/revision.pb.h"
 
-#include "exceptions.h"
+#include "base_command.h"
+
+namespace wikiopencite::citescoop::cli {
 
 namespace options = boost::program_options;
 namespace fs = std::filesystem;
 namespace cs = wikiopencite::citescoop;
 namespace proto = wikiopencite::proto;
 
-namespace wikiopencite::citescoop::cli {
 CatCommand::CatCommand()
     // NOLINTNEXTLINE(whitespace/indent_namespace)
     : BaseCommand("cat", "Display a pbf file") {
@@ -54,23 +50,19 @@ int CatCommand::Run(std::vector<std::string> args,
   auto file = fs::path(EnsureArgument<std::string>("file", parsed_args.first));
 
   std::ifstream input(file, std::ios::in | std::ios::binary);
-  auto raw_input = google::protobuf::io::IstreamInputStream(&input);
-  auto coded_input =
-      std::make_shared<google::protobuf::io::CodedInputStream>(&raw_input);
+  auto reader = cs::MessageReader(&input);
 
-  auto header = ReadMessage<proto::FileHeader>(coded_input);
-  std::shared_ptr<proto::FileHeader> header_message = std::move(header.second);
-  PrintMessage(header_message, header.first);
+  auto header = reader.ReadMessage<proto::FileHeader>();
+  PrintMessage(*header, header->ByteSizeLong());
 
-  auto revisions = ReadMessage<proto::RevisionMap>(coded_input);
-  std::shared_ptr<proto::RevisionMap> revisions_message =
-      std::move(revisions.second);
-  PrintMessage(revisions_message, revisions.first);
+  for (int64_t i = 0; i < header->revision_count(); i++) {
+    auto revision = reader.ReadMessage<proto::Revision>();
+    PrintMessage(*revision, revision->ByteSizeLong());
+  }
 
-  for (int64_t i = 0; i < header_message->page_count(); i++) {
-    auto page = ReadMessage<proto::Page>(coded_input);
-    std::shared_ptr<proto::Page> page_message = std::move(page.second);
-    PrintMessage(page_message, page.first);
+  for (int64_t i = 0; i < header->page_count(); i++) {
+    auto page = reader.ReadMessage<proto::Page>();
+    PrintMessage(*page, page->ByteSizeLong());
   }
 
   return EXIT_SUCCESS;
@@ -78,9 +70,9 @@ int CatCommand::Run(std::vector<std::string> args,
 
 void CatCommand::PrintMessage(
     // NOLINTNEXTLINE(whitespace/indent_namespace)
-    std::shared_ptr<google::protobuf::Message> message, uint32_t size) {
-  std::cout << message->GetTypeName() << " : " << size << " bytes" << '\n';
-  std::cout << message->DebugString() << '\n';
+    const google::protobuf::Message& message, uint32_t size) {
+  std::cout << message.GetTypeName() << " : " << size << " bytes" << '\n';
+  std::cout << message.DebugString() << '\n';
 }
 
 }  // namespace wikiopencite::citescoop::cli

--- a/src/commands/cat_command.h
+++ b/src/commands/cat_command.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025 The University of St Andrews
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SRC_COMMANDS_CAT_COMMAND_H_
+#define SRC_COMMANDS_CAT_COMMAND_H_
+
+#include <string>
+#include <vector>
+
+#include "google/protobuf/message.h"
+
+#include "base_command.h"
+
+namespace wikiopencite::citescoop::cli {
+
+class CatCommand : public BaseCommand {
+ public:
+  CatCommand();
+  int Run(std::vector<std::string> args, GlobalOptions globals) override;
+
+ private:
+  void PrintMessage(std::shared_ptr<google::protobuf::Message> message,
+                    uint32_t size);
+};
+
+}  // namespace wikiopencite::citescoop::cli
+
+#endif  // SRC_COMMANDS_CAT_COMMAND_H_

--- a/src/commands/cat_command.h
+++ b/src/commands/cat_command.h
@@ -4,6 +4,7 @@
 #ifndef SRC_COMMANDS_CAT_COMMAND_H_
 #define SRC_COMMANDS_CAT_COMMAND_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -19,8 +20,8 @@ class CatCommand : public BaseCommand {
   int Run(std::vector<std::string> args, GlobalOptions globals) override;
 
  private:
-  void PrintMessage(std::shared_ptr<google::protobuf::Message> message,
-                    uint32_t size);
+  static void PrintMessage(const google::protobuf::Message& message,
+                           uint32_t size);
 };
 
 }  // namespace wikiopencite::citescoop::cli

--- a/src/commands/extract_command.cc
+++ b/src/commands/extract_command.cc
@@ -317,15 +317,4 @@ void ExtractCommand::DisplayProgress(double val) {
   std::cout << "Progress: " << val << "%\r" << std::flush;
 }
 
-template <typename T>
-T ExtractCommand::EnsureArgument(const std::string& arg,
-                                 // NOLINTNEXTLINE(whitespace/indent_namespace)
-                                 const options::variables_map& args) {
-  if (!args.contains(arg)) {
-    throw MissingArgumentException("Missing required argument " + arg);
-  }
-
-  return args[arg].as<T>();
-}
-
 }  // namespace wikiopencite::citescoop::cli

--- a/src/commands/extract_command.h
+++ b/src/commands/extract_command.h
@@ -50,9 +50,6 @@ class ExtractCommand : public BaseCommand {
   static void WriteMessage(const google::protobuf::Message& message,
                            std::ostream& output);
   static void DisplayProgress(double val);
-  template <typename T>
-  static T EnsureArgument(const std::string& arg,
-                          const boost::program_options::variables_map& args);
 };
 
 }  // namespace wikiopencite::citescoop::cli

--- a/src/commands/meta_command.cc
+++ b/src/commands/meta_command.cc
@@ -1,0 +1,160 @@
+// SPDX-FileCopyrightText: 2025 The University of St Andrews
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "meta_command.h"
+
+#include <arpa/inet.h>
+#include <cstddef>
+// NOLINTNEXTLINE(build/c++17)
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <ostream>
+#include <regex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "boost/program_options/options_description.hpp"
+#include "boost/program_options/parsers.hpp"
+#include "boost/program_options/positional_options.hpp"
+#include "boost/program_options/value_semantic.hpp"
+#include "boost/program_options/variables_map.hpp"
+#include "citescoop/proto/file_header.pb.h"
+#include "citescoop/proto/language.pb.h"
+#include "citescoop/proto/page.pb.h"
+#include "citescoop/proto/revision_map.pb.h"
+#include "google/protobuf/descriptor.h"
+#include "google/protobuf/io/coded_stream.h"
+#include "google/protobuf/io/zero_copy_stream.h"
+#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include "spdlog/spdlog.h"
+
+#include "exceptions.h"
+
+namespace options = boost::program_options;
+namespace fs = std::filesystem;
+namespace cs = wikiopencite::citescoop;
+namespace proto = wikiopencite::proto;
+
+namespace wikiopencite::citescoop::cli {
+namespace {
+std::string FormatFileSize(size_t size) {
+  const char* units[] = {"B", "K", "M", "G", "T"};
+  const int numUnits = 5;
+
+  // Handle negative values
+  if (size < 0) {
+    return "0B";
+  }
+
+  // Handle zero
+  if (size == 0) {
+    return "0B";
+  }
+
+  // Calculate the appropriate unit
+  int unitIndex = 0;
+  double calc_size = static_cast<double>(size);
+
+  while (calc_size >= 1024.0 && unitIndex < numUnits - 1) {
+    calc_size /= 1024.0;
+    unitIndex++;
+  }
+
+  // Determine decimal places based on size
+  int decimalPlaces;
+  if (calc_size >= 100) {
+    decimalPlaces = 0;  // e.g., "123 MB"
+  } else if (calc_size >= 10) {
+    decimalPlaces = 1;  // e.g., "12.3 MB"
+  } else {
+    decimalPlaces = 2;  // e.g., "1.23 MB"
+  }
+
+  // Special case: bytes don't need decimals
+  if (unitIndex == 0) {
+    decimalPlaces = 0;
+  }
+
+  // Format the output
+  std::ostringstream oss;
+  oss << std::fixed << std::setprecision(decimalPlaces) << calc_size
+      << units[unitIndex];
+
+  return oss.str();
+}
+}  // namespace
+
+MetaCommand::MetaCommand()
+    // NOLINTNEXTLINE(whitespace/indent_namespace)
+    : BaseCommand("meta", "Display metainformation about a PBF file") {
+  // clang-format off
+  cli_options_.add_options()
+    ("file", options::value<std::string>()->required(), "Input file.")
+    ("pretty,p", options::bool_switch()->default_value(false),
+    "Display sizes like 1K 234M 2G etc. Uses powers of 1024");
+  positional_options_.add("file", 1);
+
+  // clang-format on
+}
+
+int MetaCommand::Run(std::vector<std::string> args,
+                     // NOLINTNEXTLINE(whitespace/indent_namespace)
+                     struct GlobalOptions) {
+  auto parsed_args = ParseArgs(args);
+  auto file = fs::path(EnsureArgument<std::string>("file", parsed_args.first));
+  auto pretty_print = EnsureArgument<bool>("pretty", parsed_args.first);
+
+  std::ifstream input(file, std::ios::in | std::ios::binary);
+  auto raw_input = google::protobuf::io::IstreamInputStream(&input);
+  auto coded_input =
+      std::make_shared<google::protobuf::io::CodedInputStream>(&raw_input);
+
+  auto header = ReadMessage<proto::FileHeader>(coded_input);
+  auto revisions = ReadMessage<proto::RevisionMap>(coded_input);
+
+  int total_page_size_disk = 0;
+  size_t total_page_size_mem = 0;
+  int total_citations = 0;
+  for (int64_t i = 0; i < header.second->page_count(); i++) {
+    auto page = ReadMessage<proto::Page>(coded_input);
+    total_page_size_disk += page.first;
+    total_page_size_mem += page.second->SpaceUsedLong();
+    total_citations += page.second->citations_size();
+  }
+
+  const google::protobuf::EnumDescriptor* descriptor =
+      proto::Language_descriptor();
+
+  auto page_size_disk_str = std::to_string(total_page_size_disk);
+  auto page_size_mem_str = std::to_string(total_page_size_mem);
+  auto revisions_size_disk_str = std::to_string(revisions.first);
+  auto revisions_size_mem_str =
+      std::to_string(revisions.second->SpaceUsedLong());
+  if (pretty_print) {
+    page_size_disk_str = FormatFileSize(total_page_size_disk);
+    page_size_mem_str = FormatFileSize(total_page_size_mem);
+    revisions_size_disk_str = FormatFileSize(revisions.first);
+    revisions_size_mem_str = FormatFileSize(revisions.second->SpaceUsedLong());
+  }
+
+  std::cout << "Language: "
+            << descriptor->FindValueByNumber(header.second->language())->name()
+            << '\n';
+  std::cout << "Total pages: " << header.second->page_count() << '\n';
+  std::cout << "Total pages size (disk): " << page_size_disk_str << '\n';
+  std::cout << "Total pages size (memory): " << page_size_mem_str << '\n';
+  std::cout << "Total citations: " << total_citations << '\n';
+  std::cout << "Total revisions: " << revisions.second->revisions_size()
+            << '\n';
+  std::cout << "Total revisions size (disk): " << revisions_size_disk_str
+            << '\n';
+  std::cout << "Total revisions size (memory): " << revisions_size_mem_str
+            << '\n';
+
+  return EXIT_SUCCESS;
+}
+
+}  // namespace wikiopencite::citescoop::cli

--- a/src/commands/meta_command.cc
+++ b/src/commands/meta_command.cc
@@ -3,15 +3,17 @@
 
 #include "meta_command.h"
 
-#include <arpa/inet.h>
+#include <array>
 #include <cstddef>
-// NOLINTNEXTLINE(build/c++17)
-#include <filesystem>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>  // NOLINT(build/c++17)
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <memory>
 #include <ostream>
-#include <regex>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -20,29 +22,26 @@
 #include "boost/program_options/parsers.hpp"
 #include "boost/program_options/positional_options.hpp"
 #include "boost/program_options/value_semantic.hpp"
-#include "boost/program_options/variables_map.hpp"
+#include "citescoop/io.h"
 #include "citescoop/proto/file_header.pb.h"
 #include "citescoop/proto/language.pb.h"
 #include "citescoop/proto/page.pb.h"
-#include "citescoop/proto/revision_map.pb.h"
+#include "citescoop/proto/revision.pb.h"
 #include "google/protobuf/descriptor.h"
-#include "google/protobuf/io/coded_stream.h"
-#include "google/protobuf/io/zero_copy_stream.h"
-#include "google/protobuf/io/zero_copy_stream_impl.h"
-#include "spdlog/spdlog.h"
 
-#include "exceptions.h"
+#include "base_command.h"
+
+namespace wikiopencite::citescoop::cli {
 
 namespace options = boost::program_options;
 namespace fs = std::filesystem;
 namespace cs = wikiopencite::citescoop;
 namespace proto = wikiopencite::proto;
 
-namespace wikiopencite::citescoop::cli {
 namespace {
 std::string FormatFileSize(size_t size) {
-  const char* units[] = {"B", "K", "M", "G", "T"};
-  const int numUnits = 5;
+  constexpr std::array<const char*, 5> kUnits = {"B", "K", "M", "G", "T"};
+  const int kUnitsSize = 5;
 
   // Handle negative values
   if (size < 0) {
@@ -55,33 +54,35 @@ std::string FormatFileSize(size_t size) {
   }
 
   // Calculate the appropriate unit
-  int unitIndex = 0;
-  double calc_size = static_cast<double>(size);
+  int unit_index = 0;
+  auto calc_size = static_cast<double>(size);
 
-  while (calc_size >= 1024.0 && unitIndex < numUnits - 1) {
-    calc_size /= 1024.0;
-    unitIndex++;
+  const double kDivisor = 1024.0;
+
+  while (calc_size >= kDivisor && unit_index < kUnitsSize - 1) {
+    calc_size /= kDivisor;
+    unit_index++;
   }
 
   // Determine decimal places based on size
-  int decimalPlaces;
-  if (calc_size >= 100) {
-    decimalPlaces = 0;  // e.g., "123 MB"
-  } else if (calc_size >= 10) {
-    decimalPlaces = 1;  // e.g., "12.3 MB"
+  int decimal_places;
+  if (calc_size >= 100) {  // NOLINT(readability-magic-numbers)
+    decimal_places = 0;
+  } else if (calc_size >= 10) {  // NOLINT(readability-magic-numbers)
+    decimal_places = 1;
   } else {
-    decimalPlaces = 2;  // e.g., "1.23 MB"
+    decimal_places = 2;
   }
 
   // Special case: bytes don't need decimals
-  if (unitIndex == 0) {
-    decimalPlaces = 0;
+  if (unit_index == 0) {
+    decimal_places = 0;
   }
 
   // Format the output
   std::ostringstream oss;
-  oss << std::fixed << std::setprecision(decimalPlaces) << calc_size
-      << units[unitIndex];
+  oss << std::fixed << std::setprecision(decimal_places) << calc_size
+      << kUnits[unit_index];
 
   return oss.str();
 }
@@ -93,7 +94,7 @@ MetaCommand::MetaCommand()
   // clang-format off
   cli_options_.add_options()
     ("file", options::value<std::string>()->required(), "Input file.")
-    ("pretty,p", options::bool_switch()->default_value(false),
+    ("pretty,p", options::value<bool>()->zero_tokens()->default_value(false),
     "Display sizes like 1K 234M 2G etc. Uses powers of 1024");
   positional_options_.add("file", 1);
 
@@ -108,21 +109,26 @@ int MetaCommand::Run(std::vector<std::string> args,
   auto pretty_print = EnsureArgument<bool>("pretty", parsed_args.first);
 
   std::ifstream input(file, std::ios::in | std::ios::binary);
-  auto raw_input = google::protobuf::io::IstreamInputStream(&input);
-  auto coded_input =
-      std::make_shared<google::protobuf::io::CodedInputStream>(&raw_input);
+  auto reader = cs::MessageReader(&input);
 
-  auto header = ReadMessage<proto::FileHeader>(coded_input);
-  auto revisions = ReadMessage<proto::RevisionMap>(coded_input);
+  auto header = reader.ReadMessage<proto::FileHeader>();
 
-  int total_page_size_disk = 0;
+  size_t total_revisions_size_disk = 0;
+  size_t total_revisions_size_mem = 0;
+  for (int64_t i = 0; i < header->revision_count(); i++) {
+    auto revision = reader.ReadMessage<proto::Revision>();
+    total_revisions_size_disk += revision->ByteSizeLong();
+    total_revisions_size_mem += revision->SpaceUsedLong();
+  }
+
+  size_t total_page_size_disk = 0;
   size_t total_page_size_mem = 0;
-  int total_citations = 0;
-  for (int64_t i = 0; i < header.second->page_count(); i++) {
-    auto page = ReadMessage<proto::Page>(coded_input);
-    total_page_size_disk += page.first;
-    total_page_size_mem += page.second->SpaceUsedLong();
-    total_citations += page.second->citations_size();
+  size_t total_citations = 0;
+  for (int64_t i = 0; i < header->page_count(); i++) {
+    auto page = reader.ReadMessage<proto::Page>();
+    total_page_size_disk += page->ByteSizeLong();
+    total_page_size_mem += page->SpaceUsedLong();
+    total_citations += page->citations_size();
   }
 
   const google::protobuf::EnumDescriptor* descriptor =
@@ -130,25 +136,23 @@ int MetaCommand::Run(std::vector<std::string> args,
 
   auto page_size_disk_str = std::to_string(total_page_size_disk);
   auto page_size_mem_str = std::to_string(total_page_size_mem);
-  auto revisions_size_disk_str = std::to_string(revisions.first);
-  auto revisions_size_mem_str =
-      std::to_string(revisions.second->SpaceUsedLong());
+  auto revisions_size_disk_str = std::to_string(total_revisions_size_disk);
+  auto revisions_size_mem_str = std::to_string(total_revisions_size_mem);
   if (pretty_print) {
     page_size_disk_str = FormatFileSize(total_page_size_disk);
     page_size_mem_str = FormatFileSize(total_page_size_mem);
-    revisions_size_disk_str = FormatFileSize(revisions.first);
-    revisions_size_mem_str = FormatFileSize(revisions.second->SpaceUsedLong());
+    revisions_size_disk_str = FormatFileSize(total_revisions_size_disk);
+    revisions_size_mem_str = FormatFileSize(total_revisions_size_mem);
   }
 
   std::cout << "Language: "
-            << descriptor->FindValueByNumber(header.second->language())->name()
+            << descriptor->FindValueByNumber(header->language())->name()
             << '\n';
-  std::cout << "Total pages: " << header.second->page_count() << '\n';
+  std::cout << "Total pages: " << header->page_count() << '\n';
   std::cout << "Total pages size (disk): " << page_size_disk_str << '\n';
   std::cout << "Total pages size (memory): " << page_size_mem_str << '\n';
   std::cout << "Total citations: " << total_citations << '\n';
-  std::cout << "Total revisions: " << revisions.second->revisions_size()
-            << '\n';
+  std::cout << "Total revisions: " << header->revision_count() << '\n';
   std::cout << "Total revisions size (disk): " << revisions_size_disk_str
             << '\n';
   std::cout << "Total revisions size (memory): " << revisions_size_mem_str

--- a/src/commands/meta_command.h
+++ b/src/commands/meta_command.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2025 The University of St Andrews
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SRC_COMMANDS_META_COMMAND_H_
+#define SRC_COMMANDS_META_COMMAND_H_
+
+#include <string>
+#include <vector>
+
+#include "google/protobuf/message.h"
+
+#include "base_command.h"
+
+namespace wikiopencite::citescoop::cli {
+
+class MetaCommand : public BaseCommand {
+ public:
+  MetaCommand();
+  int Run(std::vector<std::string> args, GlobalOptions globals) override;
+};
+
+}  // namespace wikiopencite::citescoop::cli
+
+#endif  // SRC_COMMANDS_META_COMMAND_H_

--- a/src/commands/meta_command.h
+++ b/src/commands/meta_command.h
@@ -7,8 +7,6 @@
 #include <string>
 #include <vector>
 
-#include "google/protobuf/message.h"
-
 #include "base_command.h"
 
 namespace wikiopencite::citescoop::cli {

--- a/src/main.cc
+++ b/src/main.cc
@@ -15,6 +15,7 @@
 
 #include "cli.h"
 #include "commands/base_command.h"
+#include "commands/cat_command.h"
 #include "commands/extract_command.h"
 #include "commands/help_command.h"
 
@@ -53,6 +54,10 @@ auto main(int argc, char** argv) -> int {
   cli.Register(command);
 
   command = std::shared_ptr<cli::BaseCommand>(new cli::HelpCommand(commands));
+  commands->push_back(command);
+  cli.Register(command);
+
+  command = std::shared_ptr<cli::BaseCommand>(new cli::CatCommand());
   commands->push_back(command);
   cli.Register(command);
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -18,6 +18,7 @@
 #include "commands/cat_command.h"
 #include "commands/extract_command.h"
 #include "commands/help_command.h"
+#include "commands/meta_command.h"
 
 namespace cli = wikiopencite::citescoop::cli;
 
@@ -58,6 +59,10 @@ auto main(int argc, char** argv) -> int {
   cli.Register(command);
 
   command = std::shared_ptr<cli::BaseCommand>(new cli::CatCommand());
+  commands->push_back(command);
+  cli.Register(command);
+
+  command = std::shared_ptr<cli::BaseCommand>(new cli::MetaCommand());
   commands->push_back(command);
   cli.Register(command);
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 The University of St Andrews
SPDX-License-Identifier: CC0-1.0
-->

<!--
This PR template is designed to help you write PRs that are easy for us
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary

<!-- A brief, mostly non technical summary of what this change does -->
Add some useful commands to view the generated pbf files.
Closes #12 

- [ ] Breaking Change?

# Technical Description

<!--
How does this change work? Why was this approach chosen? Were any
alternative approaches considered?
-->

## Usage

<!--
How should this change be used? Are there any changes to existing
usage, e.g. API?
-->

```
Usage: citescoop-cli [global options] cat [<args>]
cat options:
  --file arg            Input file.
```

```
Usage: citescoop-cli [global options] meta [<args>]
meta options:
  --file arg            Input file.
  -p [ --pretty ]       Display sizes like 1K 234M 2G etc. Uses powers of 1024
```

# Self Review

- [ ] I have commented my code where needed, including JSDoc / TSDoc / Docstring
- [ ] I have added / updated tests
- [ ] I have reviewed my code to ensure there are no artifacts left over from development
- [ ] I have tested my code to ensure it functions as intended
