### PR TITLE
Update citescoop version to 0.3.0

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/WikiOpenCite/registry",
-      "baseline": "760b8c93d4f163e9dcf72d7fea4cadbb03b6939d",
+      "baseline": "9b6ddf0e5cd5d27751cd9bd282edb06983389e71",
       "packages": [
         "citescoop-proto",
         "citescoop"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -24,7 +24,7 @@
     },
     {
       "name": "citescoop",
-      "version>=": "0.2.1"
+      "version>=": "0.3.0"
     },
     {
       "name": "citescoop-proto",


### PR DESCRIPTION
This will fix a number of bugs currently experienced (and we shouldn't be  using the pre-release versions really)

<!--
SPDX-FileCopyrightText: 2025 The University of St Andrews
SPDX-License-Identifier: CC0-1.0
-->

Please go to the `Preview` tab and select the appropriate template:

- [Bug Fix](?expand=1&template=bug.md)
- [Feature](?expand=1&template=feature.md)
- [Documentation](?expand=1&template=docs.md)
