### PR TITLE
Remove unused boost-uuid dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ set_property(TARGET citescoop-cli_exe PROPERTY OUTPUT_NAME citescoop-cli)
 
 target_compile_features(citescoop-cli_exe PRIVATE cxx_std_20)
 
-find_package(Boost REQUIRED COMPONENTS program_options algorithm uuid)
+find_package(Boost REQUIRED COMPONENTS program_options algorithm)
 find_package(spdlog REQUIRED)
 find_package(fmt REQUIRED)
 find_package(citescoop REQUIRED)
@@ -64,7 +64,6 @@ target_link_libraries(citescoop-cli_exe PRIVATE
   spdlog::spdlog_header_only
   Boost::program_options
   Boost::algorithm
-  Boost::uuid
   fmt::fmt
   wikiopencite::citescoop
   wikiopencite::citescoop-proto

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,10 +11,6 @@
       "version>=": "1.91.0"
     },
     {
-      "name": "boost-uuid",
-      "version>=": "1.91.0"
-    },
-    {
       "name": "boost-algorithm",
       "version>=": "1.91.0"
     },


### PR DESCRIPTION
## Summary

Removes the unused `boost-uuid` dependency.

### Changes

- Removed `boost-uuid` from `vcpkg.json`
- Removed `uuid` from the Boost components in `CMakeLists.txt`
- Removed `Boost::uuid` from the linked libraries

I searched the source code and couldn't find any usage of `boost::uuids` or any Boost UUID headers, so this dependency appears to no longer be required.