### PR TITLE
Fixed DumpFileAttributes causing segfault in extractor AddHeaders

### DIFF
--- a/src/dump/extract.cc
+++ b/src/dump/extract.cc
@@ -64,12 +64,18 @@ ExitCode ExtractCommand::Run(
 
   OpenStreams();
   std::pair<uint64_t, uint64_t> counts;
-  if (args_.stdin)
+  if (args_.stdin) {
+    spdlog::trace("Reading from stdin");
     counts =
         extractor_->Extract(std::cin, &streams_.pages, &streams_.revisions);
-  else
+  } else {
+    spdlog::trace("Reading from file: {}", args_.input);
     counts = extractor_->Extract(streams_.input, &streams_.pages,
                                  &streams_.revisions);
+  }
+
+  spdlog::info("Extracted {} pages and {} revisions", counts.first,
+               counts.second);
 
   CloseStreams();
   AddHeaders(counts);
@@ -110,54 +116,92 @@ void ExtractCommand::LoadArgs(const std::vector<std::string>& args) {
   args_.bz2 = parsed_args.first.contains("bz2");
   args_.language = WikipediaCodeToLanguage(
       ExtractLangCode(EnsureArgument<std::string>("wiki", parsed_args.first)));
+
+  spdlog::debug(
+      "Parsed arguments: input={}, pages={}, revisions={}, stdin={}, bz2={}, "
+      "language={}",
+      args_.input, args_.pages, args_.revisions, args_.stdin, args_.bz2,
+      static_cast<int>(args_.language));
 }
 
 void ExtractCommand::OpenStreams() {
-  if (!args_.stdin)
+  if (!args_.stdin) {
+    spdlog::debug("Opening input file: {}", args_.input);
     streams_.input = std::ifstream(args_.input);
+  }
 
+  spdlog::debug("Opening output file: {}", args_.pages);
   streams_.pages = std::ofstream(
       args_.pages + ".tmp", std::ios::out | std::ios::binary | std::ios::trunc);
+
+  spdlog::debug("Opening output file: {}", args_.revisions);
   streams_.revisions =
       std::ofstream(args_.revisions + ".tmp",
                     std::ios::out | std::ios::binary | std::ios::trunc);
 }
 
 void ExtractCommand::CloseStreams() {
-  if (!args_.stdin)
+  if (!args_.stdin) {
+    spdlog::trace("Closing input file: {}", args_.input);
     streams_.input.close();
+  }
 
+  spdlog::trace("Closing output file: {}", args_.pages);
   streams_.pages.close();
+
+  spdlog::trace("Closing output file: {}", args_.revisions);
   streams_.revisions.close();
 }
 
 void ExtractCommand::AddHeaders(std::pair<uint64_t, uint64_t> counts) const {
+  spdlog::debug("Adding headers to output files");
+  spdlog::trace("Opening temporary pages file: {}", args_.pages + ".tmp");
   std::ifstream tmp_pages(args_.pages + ".tmp");
+
+  spdlog::trace("Opening temporary revisions file: {}",
+                args_.revisions + ".tmp");
   std::ifstream tmp_revisions(args_.revisions + ".tmp");
+
+  spdlog::trace("Opening final pages file: {}", args_.pages);
   std::ofstream pages(args_.pages,
                       std::ios::out | std::ios::binary | std::ios::trunc);
+
+  spdlog::trace("Opening final revisions file: {}", args_.revisions);
   std::ofstream revisions(args_.revisions,
                           std::ios::out | std::ios::binary | std::ios::trunc);
-
-  auto attributes = proto::DumpFileAdditionalData();
-  attributes.set_language(args_.language);
 
   auto header = proto::FileHeader();
   header.set_count(counts.first);
   header.set_type(proto::FileType::FILE_TYPE_PAGES);
-  header.set_allocated_dump_file_attributes(&attributes);
+  header.mutable_dump_file_attributes()->set_language(args_.language);
   io::PrependHeader(header, tmp_pages, &pages);
 
   header.set_count(counts.second);
   header.set_type(proto::FileType::FILE_TYPE_REVISIONS);
   io::PrependHeader(header, tmp_revisions, &revisions);
 
+  spdlog::debug("Closing temporary and final files");
+  spdlog::trace("Closing temporary pages file: {}", args_.pages + ".tmp");
   tmp_pages.close();
+
+  spdlog::trace("Closing temporary revisions file: {}",
+                args_.revisions + ".tmp");
   tmp_revisions.close();
+
+  spdlog::trace("Closing final pages file: {}", args_.pages);
   pages.close();
+
+  spdlog::trace("Closing final revisions file: {}", args_.revisions);
   revisions.close();
 
+  spdlog::debug("Removing temporary files");
+  spdlog::trace("Removing temporary pages file: {}", args_.pages + ".tmp");
   fs::remove(args_.pages + ".tmp");
+
+  spdlog::trace("Removing temporary revisions file: {}",
+                args_.revisions + ".tmp");
   fs::remove(args_.revisions + ".tmp");
+
+  spdlog::info("Added headers to output files");
 }
 }  // namespace wikiopencite::citescoop::cli::dump

--- a/src/io.cc
+++ b/src/io.cc
@@ -93,7 +93,12 @@ void PrependHeader(uint64_t message_count, proto::FileType file_type,
 void PrependHeader(const wikiopencite::proto::FileHeader& header,
                    const std::istream& input, std::ostream* output) {
   auto writer = MessageWriter(output);
+  spdlog::trace("Writing header to output stream");
   writer.WriteMessage(header);
+
+  spdlog::trace("Copying messages to output");
   *output << input.rdbuf();
+
+  spdlog::trace("Finished writing header and messages to output stream");
 }
 }  // namespace wikiopencite::citescoop::cli::io


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: 2025 The University of St Andrews
SPDX-License-Identifier: CC0-1.0
-->

<!--
This PR template is designed to help you write PRs that are easy for us
to understand and to review, however one size doesn't fit all. Don't
feel like you need to fill all the fields for only 1 changed line. On
the same thought, if there is information that doesn't fit into the
headings but you think is needed, create a new heading.
-->

# Summary

Memory ownership assumptions were not correctly upheld leading to segfaults when the DumpFileAttributes instance was destroyed. Changed to just using the mutable object instead for simplicity (also we didn't need to handle the allocated memory ourselves)

<!-- A brief, mostly non technical summary of what this change does -->

Closes #

- [ ] Breaking Change?

# Technical Description

<!--
How does this change work? Why was this approach chosen? Were any
alternative approaches considered?
-->

## Original Bug Description

<!--
A brief description of the original bug that was fixed by this change.
-->

# Self Review

- [ ] I have commented my code where needed, including JSDoc / TSDoc / Docstring
- [ ] I have added / updated tests
- [ ] I have reviewed my code to ensure there are no artifacts left over from development
- [ ] I have tested my code to ensure it functions as intended
